### PR TITLE
feat: use AsyncLocalStorage for request-scoped user context

### DIFF
--- a/src/middlewares/userContext.ts
+++ b/src/middlewares/userContext.ts
@@ -1,5 +1,8 @@
 import { Request, Response, NextFunction } from 'express';
-import { UserContextService } from '../services/userContextService.js';
+import {
+  UserContextService,
+  asyncLocalStorage,
+} from '../services/userContextService.js';
 import { IUser } from '../types/index.js';
 
 /**
@@ -15,15 +18,10 @@ export const userContextMiddleware = async (
     const currentUser = (req as any).user as IUser;
 
     if (currentUser) {
-      // Set user context
-      const userContextService = UserContextService.getInstance();
-      userContextService.setCurrentUser(currentUser);
-
-      // Clean up user context when response ends
-      res.on('finish', () => {
-        const userContextService = UserContextService.getInstance();
-        userContextService.clearCurrentUser();
+      asyncLocalStorage.run(currentUser, () => {
+        next();
       });
+      return;
     }
 
     next();
@@ -43,38 +41,24 @@ export const sseUserContextMiddleware = async (
   next: NextFunction,
 ): Promise<void> => {
   try {
-    const userContextService = UserContextService.getInstance();
     const username = req.params.user;
 
     if (username) {
       // For user-scoped routes, set the user context
-      // Note: In a real implementation, you should validate the user exists
-      // and has proper permissions
       const user: IUser = {
         username,
         password: '',
         isAdmin: false, // TODO: Should be retrieved from user database
       };
 
-      userContextService.setCurrentUser(user);
-
-      // Clean up user context when response ends
-      res.on('finish', () => {
-        userContextService.clearCurrentUser();
+      asyncLocalStorage.run(user, () => {
+        console.log(`User context set for SSE/MCP endpoint: ${username}`);
+        next();
       });
-
-      // Also clean up on connection close for SSE
-      res.on('close', () => {
-        userContextService.clearCurrentUser();
-      });
-
-      console.log(`User context set for SSE/MCP endpoint: ${username}`);
-    } else {
-      // For global routes, clear user context (admin access)
-      userContextService.clearCurrentUser();
-      console.log('Global SSE/MCP endpoint access - no user context');
+      return;
     }
 
+    console.log('Global SSE/MCP endpoint access - no user context');
     next();
   } catch (error) {
     console.error('Error in SSE user context middleware:', error);

--- a/src/services/userContextService.ts
+++ b/src/services/userContextService.ts
@@ -1,33 +1,11 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { IUser } from '../types/index.js';
 
-// User context storage
-class UserContext {
-  private static instance: UserContext;
-  private currentUser: IUser | null = null;
-
-  static getInstance(): UserContext {
-    if (!UserContext.instance) {
-      UserContext.instance = new UserContext();
-    }
-    return UserContext.instance;
-  }
-
-  setUser(user: IUser): void {
-    this.currentUser = user;
-  }
-
-  getUser(): IUser | null {
-    return this.currentUser;
-  }
-
-  clearUser(): void {
-    this.currentUser = null;
-  }
-}
+// Shared async local storage for user context
+export const asyncLocalStorage = new AsyncLocalStorage<IUser>();
 
 export class UserContextService {
   private static instance: UserContextService;
-  private userContext = UserContext.getInstance();
 
   static getInstance(): UserContextService {
     if (!UserContextService.instance) {
@@ -37,15 +15,15 @@ export class UserContextService {
   }
 
   getCurrentUser(): IUser | null {
-    return this.userContext.getUser();
+    return asyncLocalStorage.getStore() ?? null;
   }
 
   setCurrentUser(user: IUser): void {
-    this.userContext.setUser(user);
+    asyncLocalStorage.enterWith(user);
   }
 
   clearCurrentUser(): void {
-    this.userContext.clearUser();
+    // AsyncLocalStorage automatically clears context when the async operation completes
   }
 
   isAdmin(): boolean {


### PR DESCRIPTION
## Summary
- replace singleton user context with AsyncLocalStorage
- wrap user context middlewares with asyncLocalStorage.run

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Real Client Transport Integration Tests exceeded timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d6ea1b188327808befefaaa58b12