### PR TITLE
Wrap SSE and MCP routes with async error handling

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -48,49 +48,117 @@ export class AppServer {
           console.log('MCP server initialized successfully');
 
           // Original routes (global and group-based)
-          this.app.get(`${this.basePath}/sse/:group?`, sseUserContextMiddleware, (req, res) =>
-            handleSseConnection(req, res),
+          this.app.get(
+            `${this.basePath}/sse/:group?`,
+            sseUserContextMiddleware,
+            async (req, res, next) => {
+              try {
+                await handleSseConnection(req, res);
+              } catch (e) {
+                next(e);
+              }
+            },
           );
-          this.app.post(`${this.basePath}/messages`, sseUserContextMiddleware, handleSseMessage);
+          this.app.post(
+            `${this.basePath}/messages`,
+            sseUserContextMiddleware,
+            async (req, res, next) => {
+              try {
+                await handleSseMessage(req, res);
+              } catch (e) {
+                next(e);
+              }
+            },
+          );
           this.app.post(
             `${this.basePath}/mcp/:group?`,
             sseUserContextMiddleware,
-            handleMcpPostRequest,
+            async (req, res, next) => {
+              try {
+                await handleMcpPostRequest(req, res);
+              } catch (e) {
+                next(e);
+              }
+            },
           );
           this.app.get(
             `${this.basePath}/mcp/:group?`,
             sseUserContextMiddleware,
-            handleMcpOtherRequest,
+            async (req, res, next) => {
+              try {
+                await handleMcpOtherRequest(req, res);
+              } catch (e) {
+                next(e);
+              }
+            },
           );
           this.app.delete(
             `${this.basePath}/mcp/:group?`,
             sseUserContextMiddleware,
-            handleMcpOtherRequest,
+            async (req, res, next) => {
+              try {
+                await handleMcpOtherRequest(req, res);
+              } catch (e) {
+                next(e);
+              }
+            },
           );
 
           // User-scoped routes with user context middleware
-          this.app.get(`${this.basePath}/:user/sse/:group?`, sseUserContextMiddleware, (req, res) =>
-            handleSseConnection(req, res),
+          this.app.get(
+            `${this.basePath}/:user/sse/:group?`,
+            sseUserContextMiddleware,
+            async (req, res, next) => {
+              try {
+                await handleSseConnection(req, res);
+              } catch (e) {
+                next(e);
+              }
+            },
           );
           this.app.post(
             `${this.basePath}/:user/messages`,
             sseUserContextMiddleware,
-            handleSseMessage,
+            async (req, res, next) => {
+              try {
+                await handleSseMessage(req, res);
+              } catch (e) {
+                next(e);
+              }
+            },
           );
           this.app.post(
             `${this.basePath}/:user/mcp/:group?`,
             sseUserContextMiddleware,
-            handleMcpPostRequest,
+            async (req, res, next) => {
+              try {
+                await handleMcpPostRequest(req, res);
+              } catch (e) {
+                next(e);
+              }
+            },
           );
           this.app.get(
             `${this.basePath}/:user/mcp/:group?`,
             sseUserContextMiddleware,
-            handleMcpOtherRequest,
+            async (req, res, next) => {
+              try {
+                await handleMcpOtherRequest(req, res);
+              } catch (e) {
+                next(e);
+              }
+            },
           );
           this.app.delete(
             `${this.basePath}/:user/mcp/:group?`,
             sseUserContextMiddleware,
-            handleMcpOtherRequest,
+            async (req, res, next) => {
+              try {
+                await handleMcpOtherRequest(req, res);
+              } catch (e) {
+                next(e);
+              }
+            },
           );
         })
         .catch((error) => {

--- a/tests/error-handler-routing.test.ts
+++ b/tests/error-handler-routing.test.ts
@@ -1,0 +1,84 @@
+import request from 'supertest';
+
+// Mocks for service functions
+const mockHandleSseConnection = jest.fn().mockRejectedValue(new Error('sse'));
+const mockHandleSseMessage = jest.fn().mockRejectedValue(new Error('message'));
+const mockHandleMcpPostRequest = jest.fn().mockRejectedValue(new Error('mcp-post'));
+const mockHandleMcpOtherRequest = jest.fn().mockRejectedValue(new Error('mcp-other'));
+
+jest.mock('../src/services/sseService.js', () => ({
+  handleSseConnection: mockHandleSseConnection,
+  handleSseMessage: mockHandleSseMessage,
+  handleMcpPostRequest: mockHandleMcpPostRequest,
+  handleMcpOtherRequest: mockHandleMcpOtherRequest,
+}));
+
+jest.mock('../src/services/mcpService.js', () => ({
+  initUpstreamServers: jest.fn().mockResolvedValue(undefined),
+  connected: jest.fn().mockReturnValue(true),
+}));
+
+jest.mock('../src/utils/i18n.js', () => ({
+  initI18n: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../src/models/User.js', () => ({
+  initializeDefaultUser: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../src/routes/index.js', () => ({
+  initRoutes: jest.fn(),
+}));
+
+jest.mock('../src/middlewares/index.js', () => {
+  const actual = jest.requireActual('../src/middlewares/index.js');
+  return {
+    ...actual,
+    initMiddlewares: (app: any) => {
+      app.use(actual.errorHandler);
+    },
+  };
+});
+
+import { AppServer } from '../src/server.js';
+
+describe('async route error handling', () => {
+  let app: any;
+
+  beforeAll(async () => {
+    const server = new AppServer();
+    await server.initialize();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    app = server.getApp();
+  });
+
+  test('sse connection propagates errors', async () => {
+    const res = await request(app).get('/sse');
+    expect(res.status).toBe(500);
+    expect(mockHandleSseConnection).toHaveBeenCalled();
+  });
+
+  test('sse message propagates errors', async () => {
+    const res = await request(app).post('/messages');
+    expect(res.status).toBe(500);
+    expect(mockHandleSseMessage).toHaveBeenCalled();
+  });
+
+  test('mcp post propagates errors', async () => {
+    const res = await request(app).post('/mcp');
+    expect(res.status).toBe(500);
+    expect(mockHandleMcpPostRequest).toHaveBeenCalled();
+  });
+
+  test('mcp get propagates errors', async () => {
+    const res = await request(app).get('/mcp');
+    expect(res.status).toBe(500);
+    expect(mockHandleMcpOtherRequest).toHaveBeenCalled();
+  });
+
+  test('mcp delete propagates errors', async () => {
+    const res = await request(app).delete('/mcp');
+    expect(res.status).toBe(500);
+    expect(mockHandleMcpOtherRequest).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- wrap SSE and MCP routes in async handlers to forward errors to Express error middleware
- add tests confirming route errors hit the global error handler

## Testing
- `pnpm test` *(fails: Real Client Transport Integration Tests - timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d92c51b48327b0d2aa622b6c3cd9