### PR TITLE
refactor: initialize default user only on startup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,12 +5,14 @@ const appServer = new AppServer();
 
 async function boot() {
   try {
+    // Initialization (including default user setup) runs only at startup
     await appServer.initialize();
-    appServer.start();
   } catch (error) {
-    console.error('Failed to start application:', error);
+    console.error('Failed to initialize application during startup:', error);
     process.exit(1);
   }
+
+  appServer.start();
 }
 
 boot();

--- a/src/middlewares/index.ts
+++ b/src/middlewares/index.ts
@@ -2,7 +2,6 @@ import express, { Request, Response, NextFunction } from 'express';
 import { auth } from './auth.js';
 import { userContextMiddleware } from './userContext.js';
 import { i18nMiddleware } from './i18n.js';
-import { initializeDefaultUser } from '../models/User.js';
 import config from '../config/index.js';
 
 export const errorHandler = (
@@ -46,10 +45,7 @@ export const initMiddlewares = (app: express.Application): void => {
     }
   });
 
-  // Initialize default admin user if no users exist
-  initializeDefaultUser().catch((err) => {
-    console.error('Error initializing default user:', err);
-  });
+  // Default admin user is initialized during server startup
 
   // Protect API routes with authentication middleware, but exclude auth endpoints
   app.use(`${config.basePath}/api`, (req, res, next) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -36,8 +36,9 @@ export class AppServer {
       await initI18n();
       console.log('i18n initialized successfully');
 
-      // Initialize default admin user if no users exist
+      // Initialize default admin user if no users exist (startup only)
       await initializeDefaultUser();
+      console.log('Default user initialization executed during startup');
 
       initMiddlewares(this.app);
       initRoutes(this.app);


### PR DESCRIPTION
## Summary
- initialize default admin user during server startup only
- keep AppServer initialization with explicit startup error handling
- clarify startup-only initialization in middleware comments and server logs

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Exceeded timeout of 60000 ms for a hook)*

------
https://chatgpt.com/codex/tasks/task_e_68b3de826a9c8327a1eb06e855d1b3fd