### PR TITLE
refactor(auth): remove query token usage

### DIFF
--- a/docs/features/authentication.mdx
+++ b/docs/features/authentication.mdx
@@ -113,9 +113,14 @@ const { token } = await response.json();
 
 // Use token for authenticated requests
 const serversResponse = await fetch('/api/servers', {
-  headers: { Authorization: `Bearer ${token}` },
+  headers: {
+    Authorization: `Bearer ${token}`,
+    'x-auth-token': token,
+  },
 });
 ```
+
+Tokens can be provided via the standard `Authorization` header or the `x-auth-token` header.
 
 ### API Key Authentication
 

--- a/docs/zh/features/authentication.mdx
+++ b/docs/zh/features/authentication.mdx
@@ -117,9 +117,12 @@ const { token } = await response.json();
 const protectedResponse = await fetch('/api/servers', {
   headers: {
     Authorization: `Bearer ${token}`,
+    'x-auth-token': token,
   },
 });
 ```
+
+令牌可以通过标准的 `Authorization` 头或 `x-auth-token` 头传递。
 
 ### API 密钥认证
 

--- a/docs/zh/features/monitoring.mdx
+++ b/docs/zh/features/monitoring.mdx
@@ -176,6 +176,10 @@ curl -X GET http://localhost:3000/api/monitoring/throughput \
 curl -X GET http://localhost:3000/api/monitoring/logs/stream \
   -H "Authorization: Bearer $TOKEN" \
   -H "Accept: text/event-stream"
+# 或使用 x-auth-token 头
+# curl -X GET http://localhost:3000/api/monitoring/logs/stream \\
+#   -H "x-auth-token: $TOKEN" \\
+#   -H "Accept: text/event-stream"
 
 # 过滤日志
 curl -X GET http://localhost:3000/api/monitoring/logs \

--- a/frontend/src/services/logService.ts
+++ b/frontend/src/services/logService.ts
@@ -48,49 +48,71 @@ export const useLogs = () => {
   const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
-    let eventSource: EventSource | null = null;
+    let abortController: AbortController | null = null;
     let isMounted = true;
 
-    const connectToLogStream = () => {
+    const connectToLogStream = (): void => {
       try {
-        // Close existing connection if any
-        if (eventSource) {
-          eventSource.close();
+        if (abortController) {
+          abortController.abort();
         }
 
-        // Get the authentication token
         const token = getToken();
-        // Connect to SSE endpoint with auth token in URL
-        eventSource = new EventSource(getApiUrl(`/logs/stream?token=${token}`));
+        abortController = new AbortController();
 
-        eventSource.onmessage = (event) => {
-          if (!isMounted) return;
-
-          try {
-            const data = JSON.parse(event.data);
-
-            if (data.type === 'initial') {
-              setLogs(data.logs);
-              setLoading(false);
-            } else if (data.type === 'log') {
-              setLogs((prevLogs) => [...prevLogs, data.log]);
+        fetch(getApiUrl('/logs/stream'), {
+          headers: token
+            ? {
+                Authorization: `Bearer ${token}`,
+                'x-auth-token': token,
+              }
+            : {},
+          signal: abortController.signal,
+        })
+          .then(async (response) => {
+            if (!response.body) {
+              throw new Error('ReadableStream not supported');
             }
-          } catch (err) {
-            console.error('Error parsing SSE message:', err);
-          }
-        };
 
-        eventSource.onerror = () => {
-          if (!isMounted) return;
+            const reader = response.body.getReader();
+            const decoder = new TextDecoder();
+            let buffer = '';
 
-          if (eventSource) {
-            eventSource.close();
-            // Attempt to reconnect after a delay
+            while (isMounted) {
+              const { done, value } = await reader.read();
+              if (done) {
+                if (isMounted) {
+                  setTimeout(connectToLogStream, 5000);
+                }
+                break;
+              }
+
+              buffer += decoder.decode(value, { stream: true });
+              let index;
+              while ((index = buffer.indexOf('\n\n')) !== -1) {
+                const message = buffer.slice(0, index);
+                buffer = buffer.slice(index + 2);
+                if (message.startsWith('data:')) {
+                  try {
+                    const data = JSON.parse(message.slice(5).trim());
+                    if (data.type === 'initial') {
+                      setLogs(data.logs);
+                      setLoading(false);
+                    } else if (data.type === 'log') {
+                      setLogs((prevLogs) => [...prevLogs, data.log]);
+                    }
+                  } catch (err) {
+                    console.error('Error parsing SSE message:', err);
+                  }
+                }
+              }
+            }
+          })
+          .catch((err) => {
+            if (!isMounted) return;
+            setError(err instanceof Error ? err : new Error('Failed to connect to log stream'));
             setTimeout(connectToLogStream, 5000);
-          }
-
-          setError(new Error('Connection to log stream lost, attempting to reconnect...'));
-        };
+          });
       } catch (err) {
         if (!isMounted) return;
         setError(err instanceof Error ? err : new Error('Failed to connect to log stream'));
@@ -104,8 +126,8 @@ export const useLogs = () => {
     // Cleanup on unmount
     return () => {
       isMounted = false;
-      if (eventSource) {
-        eventSource.close();
+      if (abortController) {
+        abortController.abort();
       }
     };
   }, []);

--- a/frontend/src/utils/interceptors.ts
+++ b/frontend/src/utils/interceptors.ts
@@ -27,6 +27,7 @@ export const authInterceptor: FetchInterceptor = {
 
     const token = getToken();
     if (token) {
+      headers.set('Authorization', `Bearer ${token}`);
       headers.set('x-auth-token', token);
     }
 

--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -63,10 +63,13 @@ export const auth = (req: Request, res: Response, next: NextFunction): void => {
     return;
   }
 
-  // Get token from header or query parameter
+  // Get token from headers
+  const authHeader = req.headers.authorization;
+  const bearerToken = authHeader && authHeader.startsWith('Bearer ')
+    ? authHeader.substring(7)
+    : undefined;
   const headerToken = req.header('x-auth-token');
-  const queryToken = req.query.token as string;
-  const token = headerToken || queryToken;
+  const token = bearerToken || headerToken;
 
   // Check if no token
   if (!token) {


### PR DESCRIPTION
## Summary
- drop query token merging in auth middleware and rely solely on headers
- send auth tokens via `Authorization` and `x-auth-token` headers in client and docs
- stream logs with header-based auth

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4109abf5c8327835720a587597246