### PR TITLE
Move error handling to server layer

### DIFF
--- a/src/middlewares/index.ts
+++ b/src/middlewares/index.ts
@@ -68,6 +68,4 @@ export const initMiddlewares = (app: express.Application): void => {
       });
     }
   });
-
-  app.use(errorHandler);
 };

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,7 +3,7 @@ import config from './config/index.js';
 import path from 'path';
 import fs from 'fs';
 import { initUpstreamServers, connected } from './services/mcpService.js';
-import { initMiddlewares } from './middlewares/index.js';
+import { initMiddlewares, errorHandler } from './middlewares/index.js';
 import { initRoutes } from './routes/index.js';
 import { initI18n } from './utils/i18n.js';
 import {
@@ -41,6 +41,7 @@ export class AppServer {
 
       initMiddlewares(this.app);
       initRoutes(this.app);
+      this.app.use(errorHandler);
       console.log('Server initialized successfully');
 
       initUpstreamServers()

--- a/tests/error-handler.test.ts
+++ b/tests/error-handler.test.ts
@@ -1,0 +1,18 @@
+import express from 'express';
+import request from 'supertest';
+import { initMiddlewares, errorHandler } from '../src/middlewares/index.js';
+
+describe('Global error handler', () => {
+  it('should return unified error response when route throws', async () => {
+    const app = express();
+    initMiddlewares(app);
+    app.get('/error', () => {
+      throw new Error('boom');
+    });
+    app.use(errorHandler);
+
+    const res = await request(app).get('/error');
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ success: false, message: 'Internal server error' });
+  });
+});


### PR DESCRIPTION
## Summary
- Register error handler after route initialization to capture route errors
- Remove error handler registration from middleware setup
- Add test ensuring thrown route errors return unified error response

## Testing
- `pnpm lint`
- `pnpm test tests/error-handler.test.ts`
- `pnpm test` *(fails: Exceeded timeout for hooks in integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b4109a2a708327a2c94e9c5aed3aaf